### PR TITLE
Better tablet detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-_xdo_cffi.c
-_xdo_cffi.cpython-39-x86_64-linux-gnu.so
-_xdo_cffi.o
+_xdo_cffi.*


### PR DESCRIPTION
I decided I want to emulate the Windows driver after seeing it in action, but since you already said before that you prefer keeping it simple I'm going to split the groundwork into smaller improvements that you would be able to pick and choose.

On the Windows (and OSX) driver the dial uses its middle button to switch between 3 different possible bindings. This allows to quickly switch between rotation, zoom, and brush size, for example. However, as far as the underlying USB protocol is concerned the middle button on Q620M is just Button 9, and the actual dial reading never changes as you toggle the modes.

This means that implementing this behavior requires distinguishing between different tablet models in-software and some specific code has to be written on a per-model basis. This change keeps a record of models and makes adding new VIDs and PIDs very trivial for other tablets.