### PR TITLE
Implement config changes for mode switching and key holding

### DIFF
--- a/huion_keys.py
+++ b/huion_keys.py
@@ -65,7 +65,7 @@ def main():
                if CYCLE_MODE > CYCLE_MODES:
                    CYCLE_MODE = 1
                print("Cycling to mode %s" % (CYCLE_MODE,)) 
-            elif btn in DIAL_MODES[CYCLE_MODE]:
+            elif CYCLE_MODE in DIAL_MODES and btn in DIAL_MODES[CYCLE_MODE]:
                 print("Sending %s from Mode %d" % (DIAL_MODES[CYCLE_MODE][btn], CYCLE_MODE),)
                 lib.xdo_send_keysequence_window(
                         xdo, lib.CURRENTWINDOW, DIAL_MODES[CYCLE_MODE][btn], 1000)

--- a/huion_keys.py
+++ b/huion_keys.py
@@ -117,13 +117,14 @@ def read_config(config_file):
         else:
             print("[WARN] unrecognized regular binding '%s'" % (binding,))
     #Same, but for buttons that should be held down
-    for binding in CONFIG['Hold']:
-        if binding.isdigit():
-            BUTTON_BINDINGS_HOLD[int(binding)] = CONFIG['Hold'][binding].encode('utf-8')
-        elif binding == '':
-            continue
-        else:
-            print ("[WARN] unrecognized hold binding '%s'" % (binding,))
+    if 'Hold' in CONFIG:
+        for binding in CONFIG['Hold']:
+            if binding.isdigit():
+                BUTTON_BINDINGS_HOLD[int(binding)] = CONFIG['Hold'][binding].encode('utf-8')
+            elif binding == '':
+                continue
+            else:
+                print ("[WARN] unrecognized hold binding '%s'" % (binding,))
     # Assume that if cycle is assigned we have modes for now
     if 'Dial' in CONFIG:
         CYCLE_BUTTON = int(CONFIG['Dial']['cycle'])

--- a/huion_keys.py
+++ b/huion_keys.py
@@ -60,13 +60,13 @@ def main():
                 time.sleep(3)
                 break
             print("Got button %s" % (btn,))
-            if btn == CYCLE_BUTTON:
+            if btn == CYCLE_BUTTON and CYCLE_BUTTON is not None:
                CYCLE_MODE = CYCLE_MODE + 1 
                if CYCLE_MODE > CYCLE_MODES:
                    CYCLE_MODE = 1
                print("Cycling to mode %s" % (CYCLE_MODE,)) 
             elif btn in DIAL_MODES[CYCLE_MODE]:
-                print("Sinding %s from Mode %d" % (DIAL_MODES[CYCLE_MODE][btn], CYCLE_MODE),)
+                print("Sending %s from Mode %d" % (DIAL_MODES[CYCLE_MODE][btn], CYCLE_MODE),)
                 lib.xdo_send_keysequence_window(
                         xdo, lib.CURRENTWINDOW, DIAL_MODES[CYCLE_MODE][btn], 1000)
             elif btn in BUTTON_BINDINGS_HOLD:
@@ -167,8 +167,8 @@ cycle = 9
 dial_cw=6
 dial_ccw=4
 [Mode 2]
-dial_cw=bracketright
-dial_ccw=bracketleft
+dial_cw=minus
+dial_ccw=equal
 """)
 
 


### PR DESCRIPTION
This is a major config handling change that addresses both #8 and #6.
Since the config already looked like an .ini file I went ahead and used configparser, it's in the python3 library as is, so this is pretty good for not reinventing the wheel. However, for simplicity and performance sake I kept the pre-encoding and config generation as is. 
