### PR TITLE
Commandline argument parsing and automatic udev rules generation

### DIFF
--- a/huion_keys.py
+++ b/huion_keys.py
@@ -27,7 +27,7 @@ def main():
             description='Linux utility to create custom key bindings for the Huion Kamvas Pro (2019), Inspiroy Q620M, and potentially other tablets.')
     parser.add_argument('--rules', action='store_true', default=False,
                     help='print out the udev rules for known tablets and exit')
-    parser.add_argument('-c', '--config', type=str, default='~/.config/huion_keys.conf',
+    parser.add_argument('-c', '--config', type=str,
                     help='location of config file, ~/.config/huion_keys.conf by default')
     args = parser.parse_args()
     if args.rules:
@@ -35,8 +35,11 @@ def main():
         os._exit(0)
 
     global CONFIG_FILE_PATH
-    #TODO: respect XDG_CONFIG_HOME
-    CONFIG_FILE_PATH = os.path.expanduser(args.config)
+    if args.config is None:
+        CONFIG_FILE_PATH = os.path.expanduser(os.path.join(
+                os.getenv('XDG_CONFIG_HOME', default='~/.config'), 'huion_keys.conf'))
+    else:
+        CONFIG_FILE_PATH = os.path.expanduser(args.config)
 
     global CYCLE_MODES, CYCLE_MODE, CYCLE_BUTTON
     xdo = lib.xdo_new(ffi.NULL)

--- a/huion_keys.py
+++ b/huion_keys.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import os
-import sys
 import time
 import signal
 import argparse
@@ -33,7 +32,7 @@ def main():
     args = parser.parse_args()
     if args.rules:
         make_rules()
-        sys.exit(0)
+        return 0
 
     global CONFIG_FILE_PATH
     if args.config is None:

--- a/huion_keys.py
+++ b/huion_keys.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import sys
 import time
 import signal
 import argparse
@@ -32,7 +33,7 @@ def main():
     args = parser.parse_args()
     if args.rules:
         make_rules()
-        os._exit(0)
+        sys.exit(0)
 
     global CONFIG_FILE_PATH
     if args.config is None:


### PR DESCRIPTION
I figured since we store models and their VID/PID values in the script itself this can be leveraged to easily create persistent udev rules to stop bothering with chown/sudo every time. Originally I wanted to delve into SETCAPs, but that would be overkill.
The idea is to just output a nicely formated, up-to-date udev rules file, so the user could do this:
`sudo sh -c 'python -u ./huion_keys.py --rules >> /etc/udev/rules.d/99-huion-keys.rules'`
And then never worry about file permissions after that.
Also in this PR is a config change, adding command-line options - so might as well add some flexibility there - no breaking changes/behavior changes, although respecting XDG_CONFIG_HOME just got a bit easier for those who care!